### PR TITLE
Translucent waveform plotting

### DIFF
--- a/fileExtraction/checkWaveformsStruct.m
+++ b/fileExtraction/checkWaveformsStruct.m
@@ -29,7 +29,7 @@ ratingsFields = {'ratings', 'epoch'};
 % Note that below trialInfo is intentionally omitted. If new fields are
 % added to check, trialInfo should still come at the end. This is because
 % it can be either a struct or [], so it's trickier to test for.
-fieldClasses = {'double', 'double', 'double', 'double', 'char', ...
+fieldClasses = {'double', 'double', {'double', 'single'}, {'double', 'single'}, 'char', ...
   'double', 'double', 'double', 'struct'};
 ratingsClasses = {'double', 'double'};
 
@@ -49,10 +49,15 @@ end
 
 % Check for class
 for f = 1:length(fieldClasses)
-  if ~strcmp(class(w.(requiredFields{f})), fieldClasses{f})
-    uiwait(msgbox(sprintf('Field .%s is of incorrect class. Should be %s.', requiredFields{f}, fieldClasses{f})));
-    error('checkWaveformsStruct:badFieldClass', 'Bad waveforms file');
-  end
+    if iscell(fieldClasses{f})
+        if ~ismember(class(w.(requiredFields{f})), fieldClasses{f})
+            uiwait(msgbox(sprintf('Field .%s is of incorrect class', requiredFields{f})));
+            error('checkWaveformsStruct:badFieldClass', 'Bad waveforms file');
+        end
+    elseif ~strcmp(class(w.(requiredFields{f})), fieldClasses{f})
+        uiwait(msgbox(sprintf('Field .%s is of incorrect class. Should be %s.', requiredFields{f}, fieldClasses{f})));
+        error('checkWaveformsStruct:badFieldClass', 'Bad waveforms file');
+    end
 end
 
 

--- a/mksort.m
+++ b/mksort.m
@@ -212,6 +212,8 @@ if isempty(w)
   addpath(fullfile(fPath, 'splashScreen'));
 end
 
+set(handles.mnuShowElectrodeNums, 'Checked', 'on');
+
 %--------------------------------------------------------------------------
 
 %--------------------------------------------------------------------------
@@ -222,8 +224,8 @@ end
 % Main GUI options
 
 % Number of rows and columns per screenful
-handles.nRows = 6;
-handles.nCols = 8;
+handles.nRows = 4;
+handles.nCols = 6;
 
 handles.waveMultiplier = 0.001;  % Scales the waveforms
 
@@ -1589,7 +1591,7 @@ end
 if anyUnits
   % Find range for envelopes, scale plot
   if waveLen > 0
-    maxMax = max(abs([waveMin waveMax]));
+    maxMax = double(max(abs([waveMin waveMax])));
     waveMin = -1.1 * maxMax;
     waveMax = 1.1 * maxMax;
     axLims([0 1 waveMin waveMax]);
@@ -1603,7 +1605,7 @@ if anyUnits
   % Print ratings at top of wave envelope plot
   for u = 1:handles.maxUnits
     if ~isempty(sorts.waveEnvelope(u).top)
-      text(ratingXOffset, 1.05 * maxMax, num2str(sorts.maxRatings(u)), 'color', handles.sortColors(u+1, :), 'VerticalAlignment', 'top', 'FontSize', 9);
+      text(ratingXOffset, 1.05 * maxMax, num2str(sorts.maxRatings(u)), 'Color', handles.sortColors(u+1, :), 'VerticalAlignment', 'top', 'FontSize', 9);
       ratingXOffset = ratingXOffset + 0.2;
     end
   end

--- a/mksort.m
+++ b/mksort.m
@@ -356,6 +356,7 @@ if isempty(varargin)
     1 0 0;
     0 1 0;
     0.5 0 0.5];
+  handles.sortColors(:, 4) = 0.25; % @djoshea
 
   handles.spacing = 0.01;  % How much margin to leave in each channel, so we avoid the border
 
@@ -1560,7 +1561,7 @@ for u = 1:handles.maxUnits
     waveLen = length(envelope.top);
     x = 0:(waveLen-1);
     x = [x fliplr(x)] / (waveLen-1);
-    fill(x, [envelope.top fliplr(envelope.bottom)], 1-(1-handles.sortColors(u+1, :))/2, 'EdgeColor', 'none');
+    fill(x, [envelope.top fliplr(envelope.bottom)], 1-(1-handles.sortColors(u+1, 1:3))/2, 'EdgeColor', 'none');
   end
 end
 

--- a/singleChannelEngine/oneChannelSorter.m
+++ b/singleChannelEngine/oneChannelSorter.m
@@ -524,7 +524,7 @@ handles.sortColors = [0.5 0.5 0.5;
                       1 0.2 0.2;
                       0.2 1 0.2;
                       0.5 0.2 0.5];
-handles.sortColors(:, 4) = 0.25; % @djoshea
+handles.sortColors(:, 4) = 1; % @djoshea
 
 % Color of unit highlight box
 handles.selectColor = [0.7 0.2 0];
@@ -648,8 +648,8 @@ handles.sortEpochRectHs = rectangle('Position', [1 0 handles.sorts.epochEnd 1], 
 % Set up time slider
 nWaves = size(handles.waveforms.waves, 2);
 nWavesShown = str2double(get(handles.txtNWaves, 'String'));
-set(handles.sldTime, 'Max', nWavesShown-1);
-%set(handles.sldTime, 'Max', nWaves - nWavesShown + 1);
+%set(handles.sldTime, 'Max', nWavesShown-1);
+set(handles.sldTime, 'Max', nWaves - nWavesShown + 1);
 set(handles.sldTime, 'Value', 1);
 set(handles.sldTime, 'Min', 1);
 % IJM: Changed from min("", 1) below. Caused broken slider when 

--- a/singleChannelEngine/oneChannelSorter.m
+++ b/singleChannelEngine/oneChannelSorter.m
@@ -294,7 +294,7 @@ handles.defaultEllipseWidth = 2;             % default value for ellipse diamete
 handles.defaultAcceptance = 50;              % default value for unit acceptance sliders
 handles.dragHandleSize = 0.015;              % size for hoop/ellipse drag handles
 handles.redRefracViolThresh = 2;             % percent refractory violations before number turns red on autocorrelation plot
-handles.defaultNWaves = 100;                 % Default # of waves displayed
+handles.defaultNWaves = 1000;                 % Default # of waves displayed
 handles.PCADispMult = 20;                    % one wants to see more points for PCA than for waveforms, this is factor more
 handles.initialZoom = 250;                   % initial zoom voltage (waveform view)
 handles.maxVoltage = 2000;                   % Max waveform plot voltage
@@ -520,6 +520,7 @@ handles.sortColors = [0.5 0.5 0.5;
                       1 0.2 0.2;
                       0.2 1 0.2;
                       0.5 0.2 0.5];
+handles.sortColors(:, 4) = 0.25; % @djoshea
 
 % Color of unit highlight box
 handles.selectColor = [0.7 0.2 0];
@@ -2574,10 +2575,10 @@ for unit = unitsDefined
   end
   
   % Plot
-  plot(uniqueConditions, FR(1:length(uniqueConditions)), '-', 'color', handles.sortColors(unit+1, :), 'LineWidth', 2);
+  plot(uniqueConditions, FR(1:length(uniqueConditions)), '-', 'color', handles.sortColors(unit+1, 1:3), 'LineWidth', 2);
   for dim = 1:nDims
-    plot(uniqueConditions, aboveMed(dim, 1:length(uniqueConditions)), lineStyles{dim}, 'color', handles.sortColors(unit+1, :));
-    plot(uniqueConditions, belowMed(dim, 1:length(uniqueConditions)), lineStyles{dim}, 'color', handles.sortColors(unit+1, :));
+    plot(uniqueConditions, aboveMed(dim, 1:length(uniqueConditions)), lineStyles{dim}, 'color', handles.sortColors(unit+1, 1:3));
+    plot(uniqueConditions, belowMed(dim, 1:length(uniqueConditions)), lineStyles{dim}, 'color', handles.sortColors(unit+1, 1:3));
   end
   
 end
@@ -2631,7 +2632,7 @@ for unit = unitsDefined
     try
       FRCumSum = [0 cumsum(FRs{unit}(condTrials))];
       theseTrials = uniqueTrials(condTrials);
-      color = handles.sortColors(unit+1, :) - colorRand/2 * [1 1 1] + colorRand * rand(1, 3);
+      color = handles.sortColors(unit+1, 1:3) - colorRand/2 * [1 1 1] + colorRand * rand(1, 3);
       color = max(min(color, [1 1 1]), [0 0 0]);
       kern = min(smoothKernel, length(FRCumSum)-1);
       plot(theseTrials(1:end-kern+1), (FRCumSum(kern+1:end) - FRCumSum(1:end-kern))/kern, 'color', color);
@@ -2876,8 +2877,6 @@ switch view
   case 'PCA'
     handles.PCAShown = handles.PCAPts(:, handles.wavesShownIndices);
 end
-
-
 
 function handles = displayMainPlot(handles, view, startPt, endPt)
 activateAxes(gcbf, handles.axWaves);

--- a/stats/plotAutocorrsInAxes.m
+++ b/stats/plotAutocorrsInAxes.m
@@ -62,7 +62,7 @@ for u = 1:nUnits
       plot(autocorrs(u).lags, autocorrs(u).values, 'color', color(u,:), 'LineWidth', 1.5);
     else
       bh = bar(autocorrs(u).lags, autocorrs(u).values);
-      set(bh, 'EdgeColor', color(u,:), 'FaceColor', color(u,:), 'BarWidth', 1);
+      set(bh, 'EdgeColor', color(u,1:3), 'FaceColor', color(u,1:3), 'BarWidth', 1);
     end
     
     % Figure out whether refractory violation text should be gray (OK) or


### PR DESCRIPTION
In case you are interested, it's pretty easy to modify the plotting so that the waves are semi-translucent waveforms. I find this makes it easier to see more waveforms simultaneously, so I set the default to 1000. The gist is to assign an alpha value into the fourth column of the color spec, and then to remove the opacity where it isn't desired.

![screenshot 2](https://cloud.githubusercontent.com/assets/77752/13370017/25f498a4-dcb2-11e5-9b5e-52b4d15a0ad4.png)
